### PR TITLE
Fixes #2 - Code around exception InvalidAccessToken shouldn't expect exception to occur

### DIFF
--- a/update_accounts.py
+++ b/update_accounts.py
@@ -44,12 +44,16 @@ def update_discovery_url(api_url: str, discovery_url: str):
         log.info("Access token is invalid, attempting to refresh!")
         access_token = refresh_token(api_url, TOKEN.get("refresh_token"),
                                      OAUTH.get("client_id"), OAUTH.get("client_secret"), OAUTH.get("redirect_uri"))
+        log.debug(access_token)
         CANVAS = Canvas(api_url, access_token)
         account = CANVAS.get_account(1)
 
+    try:
         # TODO: Make this URL configurable
         account.update_account_auth_settings(
             sso_settings={"auth_discovery_url": discovery_url})
+    except Exception as e:
+        log.error(f"Error updating {api_url} {e.message}")
 
 parser = argparse.ArgumentParser(description='Update Canvas Test/Beta Settings')
 parser.add_argument('canvas_token', type=str, help='Canvas Token File')


### PR DESCRIPTION
The easiest way I've found to test this is:

* Get the 2 files from canvas-update-job-secret on Test Jenkins
* Set the logging level of this `update_accounts.py` script to DEBUG at the top
* Install the requirements locally with `pip install -r requirements.txt`
* Run the script with the 2 files as parameters. It should succeed with 2 invalid tokens but also run the PUT on sso_settings

* Copy/paste one of the the access tokens from the debug log into the access token file
* Run the script again - Previously it wouldn't run the sso_settings if the token was valid

There are 2 servers updated so it will fail for one of them but succeed in another.